### PR TITLE
Fix a bug where Bind was called instead of Unbind in amqp_queue.unbind

### DIFF
--- a/rabbitpy/amqp_queue.py
+++ b/rabbitpy/amqp_queue.py
@@ -275,7 +275,7 @@ class Queue(base.AMQPClass):
         if hasattr(source, 'name'):
             source = source.name
         routing_key = routing_key or self.name
-        self._rpc(specification.Queue.Bind(queue=self.name, exchange=source,
+        self._rpc(specification.Queue.Unbind(queue=self.name, exchange=source,
                                            routing_key=routing_key))
 
     def _declare(self, passive=False):


### PR DESCRIPTION
Same bug of last pull request, this time with queue unbind :p
