### PR TITLE
Don't spin while waiting for the socket to connect.

### DIFF
--- a/rabbitpy/connection.py
+++ b/rabbitpy/connection.py
@@ -220,6 +220,7 @@ class Connection(base.StatefulObject):
             if not self._exceptions.empty():
                 exception = self._exceptions.get()
                 raise exception
+            self._events.wait(events.SOCKET_OPENED)
 
         # If the socket could not be opened, return instead of waiting
         if self.closed:


### PR DESCRIPTION
Spinning prevents rabbitpy from working with code that uses gevent and its monkey patch. For example "Connected" wouldn't get printed in the following example as the IO thread will be starved by the main thread spinning in Connection._connect():

``` python
from gevent import monkey; monkey.patch_all()
import rabbitpy

connection = rabbitpy.Connection('amqp://guest:guest@localhost/%2F?locale=en_US.UTF-8')
print "Connected"
connection.close()
```

Waiting on an event gives other greenlets a chance to run and the IO thread can complete the connection.
