### PR TITLE
Implement cancellation of Consumer

### DIFF
--- a/rabbitpy/base.py
+++ b/rabbitpy/base.py
@@ -296,6 +296,8 @@ class AMQPChannel(StatefulObject):
             value = self._read_from_queue()
             if value is not None:
                 self._check_for_rpc_request(value)
+                if isinstance(value, InternalCommand):
+                    return value
                 if frame_type and self._validate_frame_type(value, frame_type):
                     return value
                 self._read_queue.put(value)
@@ -313,3 +315,7 @@ class AMQPChannel(StatefulObject):
         self._check_for_exceptions()
         self._write_queue.put((self._channel_id, frame))
         self._trigger_write()
+
+
+class InternalCommand(object):
+    pass


### PR DESCRIPTION
Hello @gmr 
I have added `Consumer.cancel()` method and have done some refactoring. I believe that I did not make any changes that breaks backward compatibility.
In order to cancel a consuming `Consumer` I had to inject a new object (`base.InternalCommand`) into the channel's read queue when a `Basic.CancelOk` frame is received.
It does not support cancellation of multiple concurrent consumers yet because `CancelConsumer` objects do not have any identifier for consumers (`consumer_tag`). However, it works perfectly for a single consumer.
If you want a change about this, I can modify my pull request.
