### PR TITLE
fix a bug in Consumer.cancel when it is called from a different thread

### DIFF
--- a/rabbitpy/amqp_queue.py
+++ b/rabbitpy/amqp_queue.py
@@ -351,7 +351,14 @@ class Consumer(object):
 
     @property
     def _basic_cancel(self):
-        return specification.Basic.Cancel(consumer_tag=self.queue.consumer_tag)
+        frame = specification.Basic.Cancel(consumer_tag=self.queue.consumer_tag)
+        # If we wait for a reply here the CancelOK frame is consumed and
+        # Channel._consume_message cannot observe CancelOK and cannot
+        # return None to it's caller.
+        # This behavior is needed when Consumer.Cancel() is called from
+        # a different thread that runs Consumer.next_message().
+        frame.synchronous = False
+        return frame
 
     def cancel(self):
         """Cancel the consumer"""


### PR DESCRIPTION
Fixes the issue that I mention at: https://github.com/cenkalti/rabbitpy/commit/ea6a33e982c912db5815653833a77e1e71452ada#commitcomment-8033548
