### PR TITLE
Clear _wait_on_frame_interrupt in _interrupt_wait_on_frame()

### DIFF
--- a/rabbitpy/base.py
+++ b/rabbitpy/base.py
@@ -319,7 +319,7 @@ class AMQPChannel(StatefulObject):
             if self._is_debugging:
                 LOGGER.debug('No need to interrupt wait')
             return
-        self._wait_on_frame_interrupt.set()
+        self._wait_on_frame_interrupt.clear()
         if self._is_debugging:
             LOGGER.debug('Waiting for interrupt to clear')
         while self._wait_on_frame_interrupt.is_set():


### PR DESCRIPTION
In _interrupt_wait_on_frame() the _wait_on_frame_interrupt Event was set not cleared. 

It caused a infinite loop waiting for _wait_on_frame_interrupt  be cleared. Happens when connection was lost for example.