### PR TITLE
Correct delivery_mode typo in properties list

### DIFF
--- a/rabbitpy/message.py
+++ b/rabbitpy/message.py
@@ -56,7 +56,7 @@ class Message(base.AMQPClass):
     * content_type
     * content_encoding
     * correlation_id
-    * delivery_node
+    * delivery_mode
     * expiration
     * headers
     * message_id


### PR DESCRIPTION
Just a simple typo fix for the list of available properties in the Message docstring.