### PR TITLE
Fix _connect() hang on Linux and Python 2.7

### DIFF
--- a/rabbitpy/channel0.py
+++ b/rabbitpy/channel0.py
@@ -21,6 +21,8 @@ from rabbitpy import events
 from rabbitpy import exceptions
 
 LOGGER = logging.getLogger(__name__)
+default_locale = locale.getdefaultlocale()
+del locale
 
 
 class Channel0(base.AMQPChannel):
@@ -176,7 +178,7 @@ class Channel0(base.AMQPChannel):
 
         """
         if not self._args['locale']:
-            return locale.getdefaultlocale()[0] or self.DEFAULT_LOCALE
+            return default_locale[0] or self.DEFAULT_LOCALE
         return self._args['locale']
 
     @staticmethod


### PR DESCRIPTION
As tested on 3 PC (Ubuntu 14.04, 15.04, 15.10 x86_64) in virtualenv, Python 2.7.10, getdefaultlocale() blocks forever in a thread different from main. Let's cache it since it is unlikely to change at runtime.

UPDATE: tested on MacOSX, same hanging.