### PR TITLE
Add "args" property to Connection

### DIFF
--- a/rabbitpy/connection.py
+++ b/rabbitpy/connection.py
@@ -145,6 +145,10 @@ class Connection(base.StatefulObject):
             raise
         self._set_state(self.CLOSED)
         self._shutdown_connection(True)
+        
+    @property
+    def args(self):
+        return dict(self._args)
 
     @property
     def blocked(self):


### PR DESCRIPTION
Sometimes it is needed to access the information about the connection, but _args is protected and thus should not be used,