### PR TITLE
AMQP.basic_publish() bug fixed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ python:
   - 3.3
   - 3.4
 install:
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 --download-cache $HOME/.pip-cache; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install coverage==3.7.1; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 --download-cache $HOME/.pip-cache; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install coverage==3.7.1; fi
   - pip install -r requirements.txt --download-cache $HOME/.pip-cache
   - pip install -r test-requirements.txt --download-cache $HOME/.pip-cache
 script: nosetests --with-coverage --cover-package=rabbitpy -v -l DEBUG --logging-level=DEBUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
   - 3.3
   - 3.4
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 --download-cache $HOME/.pip-cache; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 --download-cache $HOME/.pip-cache; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install coverage==3.7.1; fi
   - pip install -r requirements.txt --download-cache $HOME/.pip-cache
   - pip install -r test-requirements.txt --download-cache $HOME/.pip-cache
 script: nosetests --with-coverage --cover-package=rabbitpy -v -l DEBUG --logging-level=DEBUG

--- a/rabbitpy/amqp.py
+++ b/rabbitpy/amqp.py
@@ -148,7 +148,8 @@ class AMQP(object):
         :return: bool or None
 
         """
-        msg = message.Message(self, body, properties or {}, False, False)
+        msg = message.Message(self.channel, body,
+                              properties or {}, False, False)
         return msg.publish(exchange, routing_key, mandatory, immediate)
 
     def basic_qos(self, prefetch_size=0, prefetch_count=0, global_flag=False):

--- a/tests/amqp_tests.py
+++ b/tests/amqp_tests.py
@@ -25,3 +25,6 @@ class BasicAckTests(unittest.TestCase):
             self.assertEqual(args[0].delivery_tag, 123)
             self.assertEqual(args[0].multiple, True)
 
+            # The following was causing an error in version 0.26.2, when
+            # AMQP was sending self to Message() not self.channel.
+            obj.basic_publish("exchange", "routingkey", "body")


### PR DESCRIPTION
- AMQP.basic_publish() would spit out the following:
  ValueError: channel must be a valid rabbitpy Channel object
  This is resolved and added to the unit tests.
- Coverage patch for Travis-CI (from @eandersson: gmr#85)