### PR TITLE
Unquote userame and password to accept slashes as on rfc3986

### DIFF
--- a/rabbitpy/utils.py
+++ b/rabbitpy/utils.py
@@ -35,7 +35,7 @@ def urlparse(url):
     parsed = _urlparse.urlparse(value)
     return Parsed(parsed.scheme.replace('http', 'amqp'), parsed.netloc,
                   parsed.path, parsed.params, parsed.query, parsed.fragment,
-                  parsed.username, parsed.password, parsed.hostname,
+                  _urlparse.unquote(parsed.username), _urlparse.unquote(parsed.password), parsed.hostname,
                   parsed.port)
 
 


### PR DESCRIPTION
We use usernames that have slashes on them in the form `domain/username` and rabbitpy was failing to parse the urls. Quoting slashes with %2f did not help, because a unquoting was missing after parsing


https://www.ietf.org/rfc/rfc3986.txt