### PR TITLE
Faster message body retrieval

### DIFF
--- a/rabbitpy/channel.py
+++ b/rabbitpy/channel.py
@@ -473,7 +473,7 @@ class Channel(base.AMQPChannel):
         body_length_received = 0
         body_total_size = header_value.body_size
 
-        while len(body_value) < body_total_size:
+        while body_length_received < body_total_size:
             body_part = self._wait_on_frame(CONTENT_BODY)
 
             self._check_for_rpc_request(body_part)
@@ -496,9 +496,6 @@ class Channel(base.AMQPChannel):
                 body_value += body_part.value
             else:
                 body_chunks.append(body_part.value)
-
-            if body_length_received == body_total_size:
-                break
 
         if not PYTHON3:
             body_value = ''.join(body_chunks)

--- a/rabbitpy/channel.py
+++ b/rabbitpy/channel.py
@@ -466,6 +466,9 @@ class Channel(base.AMQPChannel):
 
         error = False
 
+        # To retrieve the message body we must concatenate the binary content
+        # of several frames. The recommended idiom for this differs
+        # in py3 and py2.
         if PYTHON3:
             body_value = bytearray()
         else:
@@ -487,7 +490,6 @@ class Channel(base.AMQPChannel):
             elif consuming and not self._consumers:
                 self._reject_inbound_message(method_frame)
                 error = True
-
             if error:
                 return
 


### PR DESCRIPTION
Hi rabbitpy maintainers,

I'm using rabbitpy in a [project](https://github.com/XENON1T/pax) (https://github.com/XENON1T/pax/pull/439) to pass around large (~20 MB) messages. I noticed receiving these messages was slow, and profiling revealed rabbitpy spent a lot of its time in this line: https://github.com/gmr/rabbitpy/blob/master/rabbitpy/channel.py#L486

`_wait_for_content_frames` is assembling the content of the body in a string/bytes, adding every frame to it with `+=`. Since strings/bytes are immutable, this requires a new string/bytes to be created every time, causing an N^2 growth of memory allocation work with the number of frames. 

The [recommended idiom](https://docs.python.org/3/faq/programming.html#what-is-the-most-efficient-way-to-concatenate-many-strings-together) for concatenating multiple strings/bytes is to use bytearrays (if you're in python 3) or to construct a list first and use `''.join`. This pull request changes `_wait_for_content_frames` to use these methods (bytearray for py3, join on list of chunks in py2). 

With this change, receiving large messages went 10x faster in my application (using python 3, I did not test in python 2). Let me know if you would consider this addition. Thanks for creating rabbitpy!