### PR TITLE
Fix deadlock when access is denied during connect.

### DIFF
--- a/rabbitpy/connection.py
+++ b/rabbitpy/connection.py
@@ -208,7 +208,7 @@ class Connection(base.StatefulObject):
 
         :raises: rabbitpy.exceptions.ConnectionClosed
         """
-        if not self.open:
+        if not self.open and not self.opening:
             raise exceptions.ConnectionClosed()
         if not self._events.is_set(events.SOCKET_CLOSED):
             self._set_state(self.CLOSING)
@@ -600,7 +600,8 @@ class Connection(base.StatefulObject):
 
         """
         # Make sure the heartbeat is not running
-        self._heartbeat.stop()
+        if self._heartbeat is not None:
+            self._heartbeat.stop()
 
         if not self._events.is_set(events.SOCKET_CLOSED):
             self._close_all_channels()

--- a/rabbitpy/io.py
+++ b/rabbitpy/io.py
@@ -456,9 +456,8 @@ class IO(threading.Thread, base.StatefulObject):
 
             # If it's channel 0, call the Channel0 directly
             if value[0] == 0:
-                self._lock.acquire(True)
-                self._channels[0][0].on_frame(value[1])
-                self._lock.release()
+                with self._lock:
+                    self._channels[0][0].on_frame(value[1])
                 continue
 
             self._add_frame_to_read_queue(value[0], value[1])


### PR DESCRIPTION
There were two problems here:

1. Connection.close was raising an exception instead of closing when  it was in the "opening" state
2. When an exception was raised, the channel0 lock in IO.on_read was  never being released -- _I'm pretty sure that this was an incidental finding, but it is something that happened_

The result was the connection getting stuck waiting for channel 0 to become available in [_connect](https://github.com/gmr/rabbitpy/blob/73437a986466b2009693700a35a3781487f510dd/rabbitpy/connection.py#L312-L318).  I fixed the problem by changing `Connection.close` to process closures when it is both open and opening.