### PR TITLE
fix Channel.close, Connection._connect

### DIFF
--- a/rabbitpy/channel.py
+++ b/rabbitpy/channel.py
@@ -107,6 +107,7 @@ class Channel(base.AMQPChannel):
 
         """
         if self._connection.closed:
+            self._set_state(self.CLOSED)
             LOGGER.debug('Channel %i close invoked when connection closed',
                          self._channel_id)
         elif self.closed:

--- a/rabbitpy/connection.py
+++ b/rabbitpy/connection.py
@@ -310,7 +310,10 @@ class Connection(base.StatefulObject):
         self._channel0.start()
 
         # Wait for Channel0 to raise an exception or negotiate the connection
+        _channel0_timeout = time.time() + 10
         while not self._channel0.open:
+            if _channel0_timeout < time.time():
+                raise TimeoutError("Channel open Timeout")
             if not self._exceptions.empty():
                 exception = self._exceptions.get()
                 self._io.stop()


### PR DESCRIPTION
1. Channel.close, When closing the channel, the connection has been closed and the channel status has not been closed

2. Connection._connect, Blocking due to network or service issues when creating a connection