### PR TITLE
feat: add support for custom client properties

### DIFF
--- a/rabbitpy/channel0.py
+++ b/rabbitpy/channel0.py
@@ -43,7 +43,7 @@ class Channel0(base.AMQPChannel):
     DEFAULT_LOCALE = 'en-US'
 
     def __init__(self, connection_args, events_obj, exception_queue,
-                 write_queue, write_trigger, connection):
+                 write_queue, write_trigger, connection, client_properties):
         super(Channel0, self).__init__(
             exception_queue, write_trigger, connection)
         self._channel_id = 0
@@ -57,6 +57,17 @@ class Channel0(base.AMQPChannel):
         self._max_channels = connection_args['channel_max']
         self._max_frame_size = connection_args['frame_max']
         self._heartbeat_interval = connection_args['heartbeat']
+        self.client_properties  = {
+            'product': 'rabbitpy',
+            'platform': 'Python {0}.{1}.{2}'.format(*sys.version_info),
+            'capabilities': {'authentication_failure_close': True,
+                             'basic.nack': True,
+                             'connection.blocked': True,
+                             'consumer_cancel_notify': True,
+                             'publisher_confirms': True},
+            'information': 'See https://rabbitpy.readthedocs.io',
+            'version': __version__}
+        self.client_properties |= client_properties
         self.properties = None
 
     def close(self):
@@ -158,17 +169,9 @@ class Channel0(base.AMQPChannel):
         :rtype: pamqp.specification.Connection.StartOk
 
         """
-        properties = {
-            'product': 'rabbitpy',
-            'platform': 'Python {0}.{1}.{2}'.format(*sys.version_info),
-            'capabilities': {'authentication_failure_close': True,
-                             'basic.nack': True,
-                             'connection.blocked': True,
-                             'consumer_cancel_notify': True,
-                             'publisher_confirms': True},
-            'information': 'See https://rabbitpy.readthedocs.io',
-            'version': __version__}
-        return specification.Connection.StartOk(client_properties=properties,
+  
+        
+        return specification.Connection.StartOk(client_properties=self.client_properties,
                                                 response=self._credentials,
                                                 locale=self._get_locale())
 

--- a/rabbitpy/channel0.py
+++ b/rabbitpy/channel0.py
@@ -169,8 +169,6 @@ class Channel0(base.AMQPChannel):
         :rtype: pamqp.specification.Connection.StartOk
 
         """
-  
-        
         return specification.Connection.StartOk(client_properties=self.client_properties,
                                                 response=self._credentials,
                                                 locale=self._get_locale())

--- a/rabbitpy/connection.py
+++ b/rabbitpy/connection.py
@@ -340,7 +340,8 @@ class Connection(base.StatefulObject):
                                  exception_queue=self._exceptions,
                                  write_queue=self._write_queue,
                                  write_trigger=self._io.write_trigger,
-                                 connection=self, client_properties=self.client_properties)
+                                 connection=self,
+                                 client_properties=self.client_properties)
 
     def _create_io_thread(self):
         """Create the IO thread and the objects it uses for communication.

--- a/rabbitpy/connection.py
+++ b/rabbitpy/connection.py
@@ -96,7 +96,7 @@ class Connection(base.StatefulObject):
 
     QUEUE_WAIT = 0.01
 
-    def __init__(self, url=None):
+    def __init__(self, url=None, client_properties={}):
         """Create a new instance of the Connection object"""
         super(Connection, self).__init__()
 
@@ -123,6 +123,9 @@ class Connection(base.StatefulObject):
         self._channels = dict()
         self._heartbeat = None
         self._io = None
+        
+        # Client properties
+        self.client_properties = client_properties
 
         # Used by Message for breaking up body frames
         self._max_frame_size = None
@@ -337,7 +340,7 @@ class Connection(base.StatefulObject):
                                  exception_queue=self._exceptions,
                                  write_queue=self._write_queue,
                                  write_trigger=self._io.write_trigger,
-                                 connection=self)
+                                 connection=self, client_properties=self.client_properties)
 
     def _create_io_thread(self):
         """Create the IO thread and the objects it uses for communication.


### PR DESCRIPTION
Here is a quick PR which adds support for specifying the client_properties when creating the connection (in addition to providing the URL). This enables you to set certain properties (like connection_name) so that it will appear in the management interface on RabbitMQ.

Wasn't sure exactly how to test this, but I'll look at it some more if this seems like it is a good addition to the project. 

Should be a non-breaking change with the default provided. 