### PR TITLE
Pass server_hostname to wrap_socket for SSL connections

### DIFF
--- a/rabbitpy/io.py
+++ b/rabbitpy/io.py
@@ -249,7 +249,10 @@ class IO(threading.Thread):
         sock = socket.socket(address_family, sock_type, protocol)
         context = self._get_ssl_context()
         if context:
-            return context.wrap_socket(sock=sock)
+            return context.wrap_socket(
+                sock=sock,
+                server_hostname=self._host,
+            )
         return sock
 
     def _get_addr_info(self) -> AddrInfo:


### PR DESCRIPTION
## Problem

All `amqps://` connections fail on Python 3.12+ with:

```
ValueError: check_hostname requires server_hostname
```

`_get_ssl_context()` creates an `SSLContext(ssl.PROTOCOL_TLS_CLIENT)`, which sets `check_hostname=True` by default. However, `_create_socket()` calls `context.wrap_socket(sock=sock)` without passing `server_hostname`, which Python's SSL module requires when hostname verification is enabled.

## Fix

Pass `server_hostname=self._host` to `wrap_socket()`. `self._host` is already set from the parsed AMQP URL at init time.

## Reproducer

```python
import rabbitpy
rabbitpy.Connection('amqps://guest:guest@localhost:5671/')
# ValueError: check_hostname requires server_hostname
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL/TLS socket handling by including the server hostname when wrapping sockets, enabling proper Server Name Indication and certificate validation for more reliable secure connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->