### PR TITLE
Do not coerce int properties if value already int

### DIFF
--- a/rabbitpy/message.py
+++ b/rabbitpy/message.py
@@ -370,7 +370,7 @@ class Message(base.AMQPClass):
                 elif not isinstance(value, str):
                     LOGGER.warning('Coercing property %s to str', key)
                     self.properties[key] = str(value)
-            elif python_type == 'int':
+            elif python_type == 'int' and not isinstance(value, int):
                 LOGGER.warning('Coercing property %s to int', key)
                 try:
                     self.properties[key] = int(value)

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -366,6 +366,12 @@ class TestNonDeliveredMessageObject(helpers.TestCase):
         self.msg._coerce_properties()
         self.assertIsInstance(self.msg.properties['priority'], int)
 
+    def test_coerce_property_int_stays_int(self):
+        self.msg.properties['priority'] = 9
+        self.msg._coerce_properties()
+        self.assertIsInstance(self.msg.properties['priority'], int)
+        self.assertEqual(self.msg.properties['priority'], 9)
+
     def test_coerce_property_str_to_empty_dict(self):
         self.msg.properties['headers'] = '9'
         self.msg._coerce_properties()


### PR DESCRIPTION
After upgrading from 2.0.1 to 3.0.1, I noticed that my logs contains lots of `WARNING:rabbitpy.message:Coercing property priority to int` lines, which is slightly annoying.

It seems to me that the cause is an unconditional coercion to int, even if the property value already is an integer--as it is in my case.

Here is a change that only does the int coercion if the value isn't an int already.

Hopefully this is okay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized integer property handling in message processing to skip unnecessary type conversions when values are already correctly typed, improving efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gmr/rabbitpy/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->